### PR TITLE
Allow for custom grid intensity limit to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The `gridAwarePower()` function will return either:
     "data": {
           "mode": "renewables", // The energy source being used
           "minimumPercentage": 95, // The minimum percentage for that energy source before grid-awareness is set to true,
-          "low-carbon percentage": number, // Data from Electricity Maps for the current low-carbon (renewables + nuclear) percentage,
-          "renewable percentage": number, // Data from Electricity Maps for the current renewables percentage
+          "renewablePercentage": number, // Only returned when mode === "renewables". Data from Electricity Maps for the current renewables percentage
+        //   "lowCarbonPercentage": number, // Only returned when mode === "low-carbon". Data from Electricity Maps for the current low-carbon (renewables + nuclear) percentage,
         },
 }
 ```
@@ -83,7 +83,13 @@ import { gridAwareCO2e } from "grid-aware-websites";
 
 const zone = "DE"; // The zone ID of the region you'd like to get grid intensity data for
 const apiKey = "your_api_key";
-const gridData = await gridAwareCO2e(zone, apiKey);
+
+const options = {
+  mode: "average", // The type of comparison used to determine grid-awareness - either average or limit. Default: average
+  minimumIntensity: 400, // The minimum grid intensity value (grams CO2e/kWh) before grid-awareness is triggered. Default: 400
+};
+
+const gridData = await gridAwareCO2e(zone, apiKey, options);
 ```
 
 The `gridAwareCO2e()` function will return either:
@@ -96,8 +102,10 @@ The `gridAwareCO2e()` function will return either:
     "gridAware": boolean, // A flag indicating if grid aware changes should be applied
     "region": "DE" // The zone ID of the region you'd like to get grid intensity data for
     "data" {
+        "mode": "average", // The comparison method being used
         "carbonIntensity": number, // The current grid intensity fetched from Electricity Maps
-        "averageIntensity": number // The annual average grid intensity for the zone being checked taken from CO2.js
+        "averageIntensity": number // Only returned when mode === "average". The annual average grid intensity for the zone being checked taken from CO2.js
+        // "minimumIntensity": 400 // Returned only when mode === "limit".
     }
 }
 ```

--- a/lib/gridIntensity.js
+++ b/lib/gridIntensity.js
@@ -68,6 +68,7 @@ const fetchGridIntensity = async (zone, apiKey, options) => {
       region: zone,
       gridAware,
       data: {
+        mode,
         carbonIntensity: data.carbonIntensity,
         averageIntensity: zoneAverageIntensity,
       },
@@ -82,6 +83,7 @@ const fetchGridIntensity = async (zone, apiKey, options) => {
       region: zone,
       gridAware,
       data: {
+        mode,
         carbonIntensity: data.carbonIntensity,
         minimumIntensity,
       },

--- a/lib/gridIntensity.js
+++ b/lib/gridIntensity.js
@@ -30,9 +30,7 @@ const fetchGridIntensity = async (zone, apiKey, options) => {
     }
 
     if (options.minimumIntensity) {
-      if (
-        isNaN(options.minimumIntensity)
-      ) {
+      if (isNaN(options.minimumIntensity)) {
         return {
           status: "error",
           message:
@@ -53,14 +51,14 @@ const fetchGridIntensity = async (zone, apiKey, options) => {
   let zoneCode = zone;
   let gridAware = false;
 
-  if (mode === "average")  {
+  if (mode === "average") {
     // If it's a 2 character zone, we need to get the equivalent 3 character zone ID to check against the data in CO2.js
     if (zone.length === 2) {
       zoneCode = codes.find((code) => code.alpha2Code === zoneCode)?.alpha3Code;
     }
-  
+
     const zoneAverageIntensity = averageIntensity.data[zoneCode];
-  
+
     if (data.carbonIntensity > zoneAverageIntensity) {
       gridAware = true;
     }
@@ -78,7 +76,7 @@ const fetchGridIntensity = async (zone, apiKey, options) => {
     if (data.carbonIntensity > minimumIntensity) {
       gridAware = true;
     }
-    
+
     return {
       status: "success",
       region: zone,

--- a/lib/gridIntensity.js
+++ b/lib/gridIntensity.js
@@ -6,6 +6,7 @@ import { codes } from "../utils/countryCodes.js";
  * Fetch the grid intensity for a given zone.
  * @param {string} zone The zone to fetch the grid intensity for.
  * @param {string} apiKey The Electricity Maps API key to use for the request.
+ * @param {object} options Additional options for the request.
  * @returns {Promise<object>} The grid intensity data for the given zone.
  * @example
  * const zone = "DE";
@@ -13,7 +14,35 @@ import { codes } from "../utils/countryCodes.js";
  * const gridIntensity = await fetchGridIntensity(zone, apiKey);
  */
 
-const fetchGridIntensity = async (zone, apiKey) => {
+const fetchGridIntensity = async (zone, apiKey, options) => {
+  let mode = "average"; // The mode of the grid intensity. Options: 'average', 'limit'
+  let minimumIntensity = 400; // The minimum grid intensity value (grams CO2e/kWh) before gridAware is set to true.
+
+  if (options) {
+    if (options.mode) {
+      if (options.mode !== "average" && options.mode !== "limit") {
+        return {
+          status: "error",
+          message: "Invalid mode. Mode must be 'average' or 'limit'.",
+        };
+      }
+      mode = options.mode;
+    }
+
+    if (options.minimumIntensity) {
+      if (
+        isNaN(options.minimumIntensity)
+      ) {
+        return {
+          status: "error",
+          message:
+            "Invalid minimumIntensity. minimumIntensity must be a number.",
+        };
+      }
+      minimumIntensity = options.minimumIntensity;
+    }
+  }
+
   const response = await getGridIntensity(zone, apiKey);
 
   if (response.status === "error") {
@@ -22,28 +51,44 @@ const fetchGridIntensity = async (zone, apiKey) => {
 
   const { data } = response;
   let zoneCode = zone;
-
-  // If it's a 2 character zone, we need to get the equivalent 3 character zone ID to check against the data in CO2.js
-  if (zone.length === 2) {
-    zoneCode = codes.find((code) => code.alpha2Code === zoneCode)?.alpha3Code;
-  }
-
-  const zoneAverageIntensity = averageIntensity.data[zoneCode];
-
   let gridAware = false;
-  if (data.carbonIntensity > zoneAverageIntensity) {
-    gridAware = true;
-  }
 
-  return {
-    status: "success",
-    region: zone,
-    gridAware,
-    data: {
-      carbonIntensity: data.carbonIntensity,
-      averageIntensity: zoneAverageIntensity,
-    },
-  };
+  if (mode === "average")  {
+    // If it's a 2 character zone, we need to get the equivalent 3 character zone ID to check against the data in CO2.js
+    if (zone.length === 2) {
+      zoneCode = codes.find((code) => code.alpha2Code === zoneCode)?.alpha3Code;
+    }
+  
+    const zoneAverageIntensity = averageIntensity.data[zoneCode];
+  
+    if (data.carbonIntensity > zoneAverageIntensity) {
+      gridAware = true;
+    }
+
+    return {
+      status: "success",
+      region: zone,
+      gridAware,
+      data: {
+        carbonIntensity: data.carbonIntensity,
+        averageIntensity: zoneAverageIntensity,
+      },
+    };
+  } else if (mode === "limit") {
+    if (data.carbonIntensity > minimumIntensity) {
+      gridAware = true;
+    }
+    
+    return {
+      status: "success",
+      region: zone,
+      gridAware,
+      data: {
+        carbonIntensity: data.carbonIntensity,
+        minimumIntensity,
+      },
+    };
+  }
 };
 
 export { fetchGridIntensity };

--- a/lib/gridIntensity.test.js
+++ b/lib/gridIntensity.test.js
@@ -52,6 +52,7 @@ test("fetchGridIntensity returns correct keys for average mode", async () => {
   expect(result).toHaveProperty("status", "success");
   expect(result).toHaveProperty("region", "DE");
   expect(result).toHaveProperty("gridAware");
+  expect(result.data).toHaveProperty("mode");
   expect(result.data).toHaveProperty("carbonIntensity");
   expect(result.data).toHaveProperty("averageIntensity");
   expect(result.data).not.toHaveProperty("minimumIntensity");
@@ -66,6 +67,7 @@ test("fetchGridIntensity returns correct keys for limit mode", async () => {
   expect(result).toHaveProperty("status", "success");
   expect(result).toHaveProperty("region", "DE");
   expect(result).toHaveProperty("gridAware");
+  expect(result.data).toHaveProperty("mode");
   expect(result.data).toHaveProperty("carbonIntensity");
   expect(result.data).toHaveProperty("minimumIntensity");
   expect(result.data).not.toHaveProperty("averageIntensity");

--- a/lib/gridIntensity.test.js
+++ b/lib/gridIntensity.test.js
@@ -39,8 +39,7 @@ test("fetchGridIntensity throws an error if the minimumIntensity is invalid", as
   const options = { minimumIntensity: "invalid" };
   await expect(fetchGridIntensity(zone, apiKey, options)).resolves.toEqual({
     status: "error",
-    message:
-      "Invalid minimumIntensity. minimumIntensity must be a number.",
+    message: "Invalid minimumIntensity. minimumIntensity must be a number.",
   });
 });
 
@@ -71,4 +70,3 @@ test("fetchGridIntensity returns correct keys for limit mode", async () => {
   expect(result.data).toHaveProperty("minimumIntensity");
   expect(result.data).not.toHaveProperty("averageIntensity");
 });
-

--- a/lib/gridIntensity.test.js
+++ b/lib/gridIntensity.test.js
@@ -20,3 +20,55 @@ test("fetchGridIntensity returns an error for an invalid zone", async () => {
     message: "Invalid Electricity Maps zone.",
   });
 });
+
+// Test to check that the mode is either 'renewable' or 'low-carbon'
+test("fetchGridIntensity throws an error if the mode is invalid", async () => {
+  const zone = "DE"; // Germany
+  const apiKey = import.meta.env.VITE_EMAPS_API_KEY;
+  const options = { mode: "invalid" };
+  await expect(fetchGridIntensity(zone, apiKey, options)).resolves.toEqual({
+    status: "error",
+    message: "Invalid mode. Mode must be 'average' or 'limit'.",
+  });
+});
+
+// Test to check that the minimumIntensity is a number
+test("fetchGridIntensity throws an error if the minimumIntensity is invalid", async () => {
+  const zone = "DE"; // Germany
+  const apiKey = import.meta.env.VITE_EMAPS_API_KEY;
+  const options = { minimumIntensity: "invalid" };
+  await expect(fetchGridIntensity(zone, apiKey, options)).resolves.toEqual({
+    status: "error",
+    message:
+      "Invalid minimumIntensity. minimumIntensity must be a number.",
+  });
+});
+
+// Test to check response structure when mode is 'average'
+test("fetchGridIntensity returns correct keys for average mode", async () => {
+  const zone = "DE";
+  const apiKey = import.meta.env.VITE_EMAPS_API_KEY;
+  const options = { mode: "average" };
+  const result = await fetchGridIntensity(zone, apiKey, options);
+  expect(result).toHaveProperty("status", "success");
+  expect(result).toHaveProperty("region", "DE");
+  expect(result).toHaveProperty("gridAware");
+  expect(result.data).toHaveProperty("carbonIntensity");
+  expect(result.data).toHaveProperty("averageIntensity");
+  expect(result.data).not.toHaveProperty("minimumIntensity");
+});
+
+// Test to check response structure when mode is 'limit'
+test("fetchGridIntensity returns correct keys for limit mode", async () => {
+  const zone = "DE";
+  const apiKey = import.meta.env.VITE_EMAPS_API_KEY;
+  const options = { mode: "limit" };
+  const result = await fetchGridIntensity(zone, apiKey, options);
+  expect(result).toHaveProperty("status", "success");
+  expect(result).toHaveProperty("region", "DE");
+  expect(result).toHaveProperty("gridAware");
+  expect(result.data).toHaveProperty("carbonIntensity");
+  expect(result.data).toHaveProperty("minimumIntensity");
+  expect(result.data).not.toHaveProperty("averageIntensity");
+});
+

--- a/lib/powerBreakdown.js
+++ b/lib/powerBreakdown.js
@@ -10,7 +10,7 @@ import { getPowerBreakdown } from "./data/electricityMaps.js";
 
 const fetchPowerBreakdown = async (zone, apiKey, options) => {
   let mode = "renewable"; // The mode of the power breakdown. Options: 'low-carbon', 'renewable'
-  let minimumPercentage = 50; // The minimum percentage of low-carbon or renewable power before grid-aware is set to true.
+  let minimumPercentage = 50; // The minimum percentage of low-carbon or renewable power before gridAware is set to true.
 
   if (options) {
     if (options.mode) {
@@ -54,24 +54,37 @@ const fetchPowerBreakdown = async (zone, apiKey, options) => {
     if (renewablePercentage <= minimumPercentage) {
       gridAware = true;
     }
+
+    return {
+      status: "success",
+      region: zone,
+      gridAware,
+      data: {
+        mode,
+        minimumPercentage,
+        renewablePercentage: data.renewablePercentage,
+      },
+    };
+
   } else if (mode === "low-carbon") {
     const fossilFreePercentage = data.fossilFreePercentage;
     if (fossilFreePercentage <= minimumPercentage) {
       gridAware = true;
     }
+
+    return {
+      status: "success",
+      region: zone,
+      gridAware,
+      data: {
+        mode,
+        minimumPercentage,
+        lowCarbonPercentage: data.lowCarbonPercentage,
+      },
+    };
   }
 
-  return {
-    status: "success",
-    region: zone,
-    gridAware,
-    data: {
-      mode,
-      minimumPercentage,
-      "low-carbon percentage": data.fossilFreePercentage,
-      "renewable percentage": data.renewablePercentage,
-    },
-  };
+  
 };
 
 export { fetchPowerBreakdown };

--- a/lib/powerBreakdown.js
+++ b/lib/powerBreakdown.js
@@ -65,7 +65,6 @@ const fetchPowerBreakdown = async (zone, apiKey, options) => {
         renewablePercentage: data.renewablePercentage,
       },
     };
-
   } else if (mode === "low-carbon") {
     const fossilFreePercentage = data.fossilFreePercentage;
     if (fossilFreePercentage <= minimumPercentage) {
@@ -83,8 +82,6 @@ const fetchPowerBreakdown = async (zone, apiKey, options) => {
       },
     };
   }
-
-  
 };
 
 export { fetchPowerBreakdown };

--- a/lib/powerBreakdown.test.js
+++ b/lib/powerBreakdown.test.js
@@ -43,3 +43,37 @@ test("fetchPowerBreakdown throws an error if the minimumPercentage is invalid", 
       "Invalid minimumPercentage. minimumPercentage must be a number between 0 and 100.",
   });
 });
+
+// Test to check response structure when mode is renewable
+test("fetchPowerBreakdown returns correct structure for renewable mode", async () => {
+  const zone = "DE";
+  const apiKey = import.meta.env.VITE_EMAPS_API_KEY;
+  const options = { mode: "renewable" };
+  const result = await fetchPowerBreakdown(zone, apiKey, options);
+  
+  expect(result).toHaveProperty("status", "success");
+  expect(result).toHaveProperty("region", zone);
+  expect(result).toHaveProperty("gridAware");
+  expect(result).toHaveProperty("data");
+  expect(result.data).toHaveProperty("mode", "renewable");
+  expect(result.data).toHaveProperty("minimumPercentage");
+  expect(result.data).toHaveProperty("renewablePercentage");
+  expect(result.data).not.toHaveProperty("lowCarbonPercentage");
+});
+
+// Test to check response structure when mode is low-carbon
+test("fetchPowerBreakdown returns correct structure for low-carbon mode", async () => {
+  const zone = "DE";
+  const apiKey = import.meta.env.VITE_EMAPS_API_KEY;
+  const options = { mode: "low-carbon" };
+  const result = await fetchPowerBreakdown(zone, apiKey, options);
+  
+  expect(result).toHaveProperty("status", "success");
+  expect(result).toHaveProperty("region", zone);
+  expect(result).toHaveProperty("gridAware");
+  expect(result).toHaveProperty("data");
+  expect(result.data).toHaveProperty("mode", "low-carbon");
+  expect(result.data).toHaveProperty("minimumPercentage");
+  expect(result.data).toHaveProperty("lowCarbonPercentage");
+  expect(result.data).not.toHaveProperty("renewablePercentage");
+});

--- a/lib/powerBreakdown.test.js
+++ b/lib/powerBreakdown.test.js
@@ -50,7 +50,7 @@ test("fetchPowerBreakdown returns correct structure for renewable mode", async (
   const apiKey = import.meta.env.VITE_EMAPS_API_KEY;
   const options = { mode: "renewable" };
   const result = await fetchPowerBreakdown(zone, apiKey, options);
-  
+
   expect(result).toHaveProperty("status", "success");
   expect(result).toHaveProperty("region", zone);
   expect(result).toHaveProperty("gridAware");
@@ -67,7 +67,7 @@ test("fetchPowerBreakdown returns correct structure for low-carbon mode", async 
   const apiKey = import.meta.env.VITE_EMAPS_API_KEY;
   const options = { mode: "low-carbon" };
   const result = await fetchPowerBreakdown(zone, apiKey, options);
-  
+
   expect(result).toHaveProperty("status", "success");
   expect(result).toHaveProperty("region", zone);
   expect(result).toHaveProperty("gridAware");


### PR DESCRIPTION
This PR allows the user to set at custom grid intensity limit when using the `gridAwareCO2e` function.

This is done by the user first specifying the `mode` they want to use to determine if grid-awareness should be triggered. The `mode` can either be set to:

- `"average"` (default): perform a comparison of the current grid intensity against the annual average.
- `"limit"`: perform a comparison of the current grid intensity against an arbitrary value that is set by the developer.

When `mode === "limit"`, the developer can then set a `minimumIntensity` value that is used for comparison. The default value is currently set to 400 (grams CO2e/kWh).

Example: 

```js
import { gridAwareCO2e } from "grid-aware-websites";

const zone = "DE"; // The zone ID of the region you'd like to get grid intensity data for
const apiKey = "your_api_key";

const options = {
  mode: "limit",
  minimumIntensity: 250, 
};

const gridData = await gridAwareCO2e(zone, apiKey, options);
```