### PR TITLE
Add project explainer to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 > [!CAUTION] > _This repository is currently under active development. It is **not advised** that this code be used in any critical production systems._
 
+This library is part of the grid-aware websites toolkit developed by [Green Web Foundation](https://www.thegreenwebfoundation.org). The aim of the toolkit is to considerably reduce the barrier to entry for developers and designers seeking to build grid-aware websites. It consists of three parts:
+
+1. This codebase
+1. Technical documentation
+1. UX/UI design catalogue
+
+[Read about the project on our website](https://www.thegreenwebfoundation.org/tools/grid-aware-websites/).
+
+
 ## Installing this library
 
 You can install this library using NPM.
@@ -138,7 +147,3 @@ This library can be used anywhere that runs server-side JavaScript and can make 
 
 - [Cloudflare Workers Demo Site](https://github.com/thegreenwebfoundation/grid-aware-websites-demo-cloudflare)
 - [Netlify Edge Functions Demo Site](https://github.com/thegreenwebfoundation/grid-aware-websites-demo-netlify)
-
-To do:
-
-- [ ] Add some text explaining the project (or linking to an explainer).


### PR DESCRIPTION
Add a short intro section at the top of the readme file so the project has some context in the wider grid-aware toolkit and project.