### PR TITLE
Remove zone check for electricity maps

### DIFF
--- a/lib/gridIntensity.js
+++ b/lib/gridIntensity.js
@@ -1,7 +1,6 @@
 import { getGridIntensity } from "./data/electricityMaps.js";
 import { averageIntensity } from "@tgwf/co2";
 import { codes } from "../utils/countryCodes.js";
-import { zoneTypeCheck } from "../utils/index.js";
 
 /**
  * Fetch the grid intensity for a given zone.
@@ -19,10 +18,6 @@ const fetchGridIntensity = async (zone, apiKey, options) => {
   let mode = "average"; // The mode of the grid intensity. Options: 'average', 'limit'
   let minimumIntensity = 400; // The minimum grid intensity value (grams CO2e/kWh) before gridAware is set to true.
 
-  const zoneCheck = zoneTypeCheck(zone)
-  if (zoneCheck?.status === "error") {
-    return zoneCheck;
-  }
 
   if (options) {
     if (options.mode) {

--- a/lib/gridIntensity.test.js
+++ b/lib/gridIntensity.test.js
@@ -79,7 +79,7 @@ test("fetchGridIntensity throws an error if the zone parameter is invalid", asyn
   const apiKey = import.meta.env.VITE_EMAPS_API_KEY;
   await expect(fetchGridIntensity(zone, apiKey)).resolves.toEqual({
     status: "error",
-    message: "Invalid zone. Zone must be a string or object.",
+    message: "Invalid zone. Zone object must contain lat and lon properties.",
   });
 
   const zone2 = "DE"; // Valid string

--- a/lib/powerBreakdown.js
+++ b/lib/powerBreakdown.js
@@ -1,5 +1,4 @@
 import { getPowerBreakdown } from "./data/electricityMaps.js";
-import { zoneTypeCheck } from "./utils/index.js";
 
 /**
  * Fetch the power breakdown for a given zone.
@@ -12,11 +11,6 @@ import { zoneTypeCheck } from "./utils/index.js";
 const fetchPowerBreakdown = async (zone, apiKey, options) => {
   let mode = "renewable"; // The mode of the power breakdown. Options: 'low-carbon', 'renewable'
   let minimumPercentage = 50; // The minimum percentage of low-carbon or renewable power before gridAware is set to true.
-
-  const zoneCheck = zoneTypeCheck(zone);
-  if (zoneCheck?.status === "error") {
-    return zoneCheck;
-  }
 
   if (options) {
     if (options.mode) {

--- a/lib/powerBreakdown.test.js
+++ b/lib/powerBreakdown.test.js
@@ -84,7 +84,7 @@ test("fetchPowerBreakdown throws an error if the zone parameter is invalid", asy
   const apiKey = import.meta.env.VITE_EMAPS_API_KEY;
   await expect(fetchPowerBreakdown(zone, apiKey)).resolves.toEqual({
     status: "error",
-    message: "Invalid zone. Zone must be a string or object.",
+    message: "Invalid zone. Zone object must contain lat and lon properties.",
   });
 
   const zone2 = "DE"; // Valid string

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,8 +1,0 @@
-export const zoneTypeCheck = (zone) => {
-  if (typeof zone !== "string" && typeof zone !== "object") {
-    return {
-      status: "error",
-      message: "Invalid zone. Zone must be a string or object.",
-    };
-  }
-}


### PR DESCRIPTION
This PR removes the code which makes a pre-emptive check to ensure the zone being provided is a valid electricity maps zone. Refer to #10 for reasoning behind removing this.